### PR TITLE
Remove Windows crt and version warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ if(Qt5_FOUND)
 	set(CMAKE_AUTOUIC ON)
 endif()
 
+if (WIN32)
+	add_definitions("-D_CRT_SECURE_NO_WARNINGS -D_WIN32_WINNT=0x0601") # Windows 7
+endif()
+
 # Include sub-projects.
 add_subdirectory ("DSCSTools")
 


### PR DESCRIPTION
- Default Windows paltform is defined as Windows 7 (0x601)
- Remove boring warning about Crt secue functions (*_s)